### PR TITLE
SAS-2: Enable write permissions for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write  # Important for pushing tags or commits
+
 jobs:
   build-and-test:
     uses: ./.github/workflows/common.yml


### PR DESCRIPTION
Added 'permissions: contents: write' to the release workflow to allow GitHub Actions to push tags and commits. This resolves the 'git-receive-pack not permitted' error during the Gradle release process caused by insufficient GitHub token permissions.