### PR TITLE
SAS-5: Fetch full git history in CI workflows

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 23
         uses: actions/setup-java@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Fetch all tags
         run: git fetch --tags --force


### PR DESCRIPTION
The release workflow is failing with a 'RefAlreadyExistsException' because the Axion Release plugin was unable to determine the correct next version. This seems to be caused by the default shallow clone in the checkout step, which does not provide the full commit history required by Axion to find the latest version tag. This commit updates the checkout step to use `fetch-depth: 0`, ensuring a full clone of the repository. This allows the release plugin to access the entire history, correctly calculate the next version, and prevent release failures